### PR TITLE
refactor : UserIdTokenContextHolder 리팩토링

### DIFF
--- a/waldreg/core-layer/util/src/main/java/org/waldreg/util/DecryptedTokenContextHolder.java
+++ b/waldreg/core-layer/util/src/main/java/org/waldreg/util/DecryptedTokenContextHolder.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserIdContextHolder{
+public class DecryptedTokenContextHolder{
 
     private static final ThreadLocal<Map<String, Integer>> threadLocal;
     private static final String key;
@@ -19,10 +19,13 @@ public class UserIdContextHolder{
         threadLocal.get().put(key, id);
     }
 
-    public int resolve(){
+    public int get(){
+        return threadLocal.get().get(key);
+    }
+
+    public void resolve(){
         int id = threadLocal.get().get(key);
         threadLocal.remove();
-        return id;
     }
 
 }

--- a/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/management/CharacterManager.java
+++ b/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/management/CharacterManager.java
@@ -9,6 +9,8 @@ public interface CharacterManager{
 
     CharacterDto readCharacter(String characterName);
 
+    CharacterDto readCharacterByUserId(int id);
+
     List<CharacterDto> readCharacterList();
 
     void updateCharacter(String targetName, CharacterDto changedCharacter);

--- a/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/management/DefaultCharacterManager.java
+++ b/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/management/DefaultCharacterManager.java
@@ -52,6 +52,11 @@ public class DefaultCharacterManager implements CharacterManager{
     }
 
     @Override
+    public CharacterDto readCharacterByUserId(int id){
+        return characterRepository.readCharacterByUserId(id);
+    }
+
+    @Override
     public List<CharacterDto> readCharacterList(){
         return characterRepository.readCharacterList();
     }

--- a/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/spi/CharacterRepository.java
+++ b/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/spi/CharacterRepository.java
@@ -9,6 +9,8 @@ public interface CharacterRepository{
 
     CharacterDto readCharacter(String characterName);
 
+    CharacterDto readCharacterByUserId(int id);
+
     List<CharacterDto> readCharacterList();
 
     void updateCharacter(String targetName, CharacterDto changedCharacter);

--- a/waldreg/stable-service-layer/character/src/test/java/org/waldreg/character/management/DefaultCharacterManagerTest.java
+++ b/waldreg/stable-service-layer/character/src/test/java/org/waldreg/character/management/DefaultCharacterManagerTest.java
@@ -126,6 +126,29 @@ public class DefaultCharacterManagerTest{
     }
 
     @Test
+    @DisplayName("유저 id에 속한 Character 조회 테스트")
+    public void READ_CHARACTER_BY_USER_ID_TEST(){
+        // given
+        int id = 1;
+        String characterName = "admin";
+        CharacterDto characterDto = CharacterDto.builder()
+                .characterName(characterName)
+                .permissionDtoList(List.of(
+                        PermissionDto.builder()
+                                .name(permissionName)
+                                .status("fail")
+                                .build()
+                )).build();
+
+        // when
+        Mockito.when(defaultCharacterManager.readCharacterByUserId(id)).thenReturn(characterDto);
+        CharacterDto result = defaultCharacterManager.readCharacterByUserId(id);
+
+        // then
+        Assertions.assertEquals("admin", characterDto.getCharacterName());
+    }
+
+    @Test
     @DisplayName("Character 목록 조회 성공 테스트")
     public void READ_CHARACTER_LIST_SUCCESS_TEST(){
         // given


### PR DESCRIPTION
UserIdContextHolder의 이름을 DecrytedTokenContextHolder로 변경함. UserIdContext의 resolve메소드를 resolve메소드와 get메소드로 분리함.