### PR TITLE
fix : Decrypted 된 token이 없을경우 유의미한 예외를 반환하도록 수정함

### DIFF
--- a/waldreg/core-layer/util/src/main/java/org/waldreg/util/DecryptedTokenContextHolder.java
+++ b/waldreg/core-layer/util/src/main/java/org/waldreg/util/DecryptedTokenContextHolder.java
@@ -3,6 +3,7 @@ package org.waldreg.util;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.stereotype.Service;
+import org.waldreg.util.exception.DecryptedTokenDoesNotExistException;
 
 @Service
 public class DecryptedTokenContextHolder{
@@ -20,11 +21,14 @@ public class DecryptedTokenContextHolder{
     }
 
     public int get(){
-        return threadLocal.get().get(key);
+        try{
+            return threadLocal.get().get(key);
+        } catch (NullPointerException NPE){
+            throw new DecryptedTokenDoesNotExistException();
+        }
     }
 
     public void resolve(){
-        int id = threadLocal.get().get(key);
         threadLocal.remove();
     }
 

--- a/waldreg/core-layer/util/src/main/java/org/waldreg/util/exception/DecryptedTokenDoesNotExistException.java
+++ b/waldreg/core-layer/util/src/main/java/org/waldreg/util/exception/DecryptedTokenDoesNotExistException.java
@@ -1,0 +1,9 @@
+package org.waldreg.util.exception;
+
+public class DecryptedTokenDoesNotExistException extends RuntimeException{
+
+    public DecryptedTokenDoesNotExistException(){
+        super("Can not find decrypted token");
+    }
+
+}


### PR DESCRIPTION
- Decrypted된 token이 없는데, DecryptedTokenContextHolder에 get()요청을 한 경우, 유의미한 예외를 반환하도록 수정함.
- NullPointerException.class -> DecryptedTokenDoestNotExistException.class