### PR TITLE
fix : CharacterControllerAdvice 잘못된 파라미터 수정

### DIFF
--- a/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/exceptionadvice/CharacterControllerAdvice.java
+++ b/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/exceptionadvice/CharacterControllerAdvice.java
@@ -25,7 +25,7 @@ public class CharacterControllerAdvice{
     }
 
     @ExceptionHandler({UnknownPermissionException.class, UnknownPermissionStatusException.class})
-    public ResponseEntity<ExceptionTemplate> catchUnknownPermissionExceptions(UnknownPermissionException unknownPermissionException){
+    public ResponseEntity<ExceptionTemplate> catchUnknownPermissionExceptions(RuntimeException unknownPermissionException){
         ExceptionTemplate exceptionTemplate = ExceptionTemplate.builder()
                 .message(unknownPermissionException.getMessage())
                 .documentUrl(documentUrl)


### PR DESCRIPTION
- CharacterControllerAdvice가 UnknownPermissionException.class 와 UnknownPermissionStatusException.class를 잡고 둘중 한 타입으로 파라미터를 받는 오류를 수정했습니다.