### PR TITLE
fix : 새로운 Character생성시 permission이 비어있다면, 없는권한으로 지정

### DIFF
--- a/waldreg/application-layer/acceptance/src/test/java/org/waldreg/acceptance/permission/PermissionAcceptanceTest.java
+++ b/waldreg/application-layer/acceptance/src/test/java/org/waldreg/acceptance/permission/PermissionAcceptanceTest.java
@@ -734,6 +734,50 @@ public class PermissionAcceptanceTest{
         );
     }
 
+    @Test
+    @DisplayName("역할 생성 실패 테스트 - 역할 이름에 공백이 들어옴")
+    public void CREATE_CHARACTER_FAIL_BLANK_CHARACTER_NAME_TEST() throws Exception{
+        // given
+        String token = AuthenticationAcceptanceTestHelper.getAdminToken(mvc, objectMapper);
+        CharacterRequest characterRequest = CharacterRequest.builder()
+                .characterName(" ")
+                .permissionList(List.of())
+                .build();
+
+        // when
+        ResultActions resultActions = PermissionAcceptanceTestHelper.createCharacter(mvc, token, objectMapper.writeValueAsString(characterRequest));
+
+        // then
+        resultActions.andExpectAll(
+                MockMvcResultMatchers.status().isBadRequest(),
+                MockMvcResultMatchers.header().string("Api-version", "1.0")
+        ).andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("새로운 역할 생성 및 조회 성공 테스트 - permission에 공백")
+    public void CREATE_CHARACTER_SUCCESS_TEST_BLANK_PERMISSION() throws Exception{
+        // given
+        String token = AuthenticationAcceptanceTestHelper.getAdminToken(mvc, objectMapper);
+        String characterName = "hello world";
+        CharacterRequest characterRequest = CharacterRequest.builder()
+                .characterName(characterName)
+                .permissionList(List.of())
+                .build();
+
+        // when
+        PermissionAcceptanceTestHelper.createCharacter(mvc, token, objectMapper.writeValueAsString(characterRequest));
+        deleteWaitCharacterList.add(characterName);
+        ResultActions resultActions = PermissionAcceptanceTestHelper.inquirySpecificCharacter(mvc, characterName, token);
+
+        // then
+        resultActions.andExpectAll(
+                MockMvcResultMatchers.status().isOk(),
+                MockMvcResultMatchers.header().string("Api-version", "1.0"),
+                MockMvcResultMatchers.jsonPath("$.character_name").value(characterName)
+        ).andDo(MockMvcResultHandlers.print());
+    }
+
     private String createUserAndGetToken(String name, String userId, String userPassword) throws Exception{
         UserRequest userRequest = UserRequest.builder()
                 .name(name)

--- a/waldreg/application-layer/acceptance/src/test/java/org/waldreg/acceptance/permission/PermissionAcceptanceTest.java
+++ b/waldreg/application-layer/acceptance/src/test/java/org/waldreg/acceptance/permission/PermissionAcceptanceTest.java
@@ -346,11 +346,7 @@ public class PermissionAcceptanceTest{
                 MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON),
                 MockMvcResultMatchers.header().string(HttpHeaders.CONTENT_TYPE, "application/json"),
                 MockMvcResultMatchers.header().string("Api-version", apiVersion),
-                MockMvcResultMatchers.jsonPath("$.character_name").value(characterName),
-                MockMvcResultMatchers.jsonPath("$.permissions.[0].permission_name")
-                        .value(permissionName),
-                MockMvcResultMatchers.jsonPath("$.permissions.[0].permission_status")
-                        .value(permissionStatus)
+                MockMvcResultMatchers.jsonPath("$.character_name").value(characterName)
         );
     }
 

--- a/waldreg/application-layer/application-configurer/src/main/java/org/waldreg/config/globalexceptionadvice/RequestValidationAdvice.java
+++ b/waldreg/application-layer/application-configurer/src/main/java/org/waldreg/config/globalexceptionadvice/RequestValidationAdvice.java
@@ -14,7 +14,7 @@ public class RequestValidationAdvice{
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionTemplate> catchValidationException(MethodArgumentNotValidException methodArgumentNotValidException){
         ExceptionTemplate exceptionTemplate = ExceptionTemplate.builder()
-                .message(methodArgumentNotValidException.getMessage())
+                .message(methodArgumentNotValidException.getBindingResult().getAllErrors().get(0).getDefaultMessage())
                 .documentUrl(documentUrl)
                 .build();
         return new ResponseEntity<>(exceptionTemplate, HttpStatus.BAD_REQUEST);

--- a/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/response/SpecifyStatusPermissionResponse.java
+++ b/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/response/SpecifyStatusPermissionResponse.java
@@ -6,8 +6,6 @@ public final class SpecifyStatusPermissionResponse{
 
     @JsonProperty("permission_name")
     private final String name;
-    @JsonProperty("permission_info")
-    private final String info;
     @JsonProperty("permission_status")
     private final String status;
 
@@ -17,7 +15,6 @@ public final class SpecifyStatusPermissionResponse{
 
     private SpecifyStatusPermissionResponse(Builder builder){
         this.name = builder.name;
-        this.info = builder.info;
         this.status = builder.status;
     }
 
@@ -29,10 +26,6 @@ public final class SpecifyStatusPermissionResponse{
         return this.name;
     }
 
-    public String getInfo(){
-        return this.info;
-    }
-
     public String getStatus(){
         return status;
     }
@@ -40,18 +33,12 @@ public final class SpecifyStatusPermissionResponse{
     public static final class Builder{
 
         private String name;
-        private String info;
         private String status;
 
         private Builder(){}
 
         public Builder name(String name){
             this.name = name;
-            return this;
-        }
-
-        public Builder info(String info){
-            this.info = info;
             return this;
         }
 

--- a/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/management/DefaultCharacterManager.java
+++ b/waldreg/stable-service-layer/character/src/main/java/org/waldreg/character/management/DefaultCharacterManager.java
@@ -1,6 +1,9 @@
 package org.waldreg.character.management;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.waldreg.character.dto.CharacterDto;
@@ -8,6 +11,8 @@ import org.waldreg.character.dto.PermissionDto;
 import org.waldreg.character.exception.NoPermissionException;
 import org.waldreg.character.exception.UnknownPermissionException;
 import org.waldreg.character.exception.UnknownPermissionStatusException;
+import org.waldreg.character.permission.core.PermissionUnit;
+import org.waldreg.character.permission.management.PermissionUnitListReadable;
 import org.waldreg.character.spi.CharacterRepository;
 
 @Service
@@ -15,12 +20,14 @@ public class DefaultCharacterManager implements CharacterManager{
 
     private final CharacterRepository characterRepository;
     private final PermissionChecker permissionChecker;
+    private final PermissionUnitListReadable permissionUnitListReadable;
     private final String[] deletedBlockedPermissionNames = {"Admin", "Guest"};
 
     @Override
     public void createCharacter(CharacterDto characterDto){
         throwIfInvalidPermissionDetected(characterDto.getPermissionList());
-        characterRepository.createCharacter(characterDto);
+        CharacterDto filledCharacterDto = fillAbsentPermissionToCharacterDto(characterDto);
+        characterRepository.createCharacter(filledCharacterDto);
     }
 
     @Override
@@ -46,6 +53,51 @@ public class DefaultCharacterManager implements CharacterManager{
         if (!permissionChecker.isPossiblePermissionStatus(permissionDto.getName(), permissionDto.getStatus())){
             throw new UnknownPermissionStatusException(permissionDto.getName(), permissionDto.getStatus());
         }
+    }
+
+    private CharacterDto fillAbsentPermissionToCharacterDto(CharacterDto characterDto){
+        Map<String, PermissionDto> permissionDtoMap = convertListToMap(characterDto.getPermissionList());
+        fillAbsentPermissions(permissionDtoMap, false);
+        return CharacterDto.builder()
+                .characterName(characterDto.getCharacterName())
+                .permissionDtoList(convertMapToList(permissionDtoMap))
+                .build();
+    }
+
+    private Map<String, PermissionDto> convertListToMap(List<PermissionDto> permissionDtoList){
+        Map<String, PermissionDto> permissionDtoMap = new HashMap<>();
+        for(PermissionDto permissionDto : permissionDtoList){
+            permissionDtoMap.put(permissionDto.getName(), permissionDto);
+        }
+        return permissionDtoMap;
+    }
+
+    private void fillAbsentPermissions(Map<String, PermissionDto> permissionDtoMap, boolean absentStatus){
+        List<PermissionUnit> permissionUnitList = permissionUnitListReadable.getPermissionUnitList();
+        for(PermissionUnit permissionUnit : permissionUnitList){
+            if(!permissionDtoMap.containsKey(permissionUnit.getName())){
+                PermissionDto permissionDto = PermissionDto.builder()
+                        .name(permissionUnit.getName())
+                        .status(getStatusOfPermissionUnit(permissionUnit, absentStatus))
+                        .build();
+                permissionDtoMap.put(permissionUnit.getName(), permissionDto);
+            }
+        }
+    }
+
+    private String getStatusOfPermissionUnit(PermissionUnit permissionUnit, boolean targetStatus){
+        for(String status : permissionUnit.getStatusList()){
+            if(permissionUnit.verify(status) == targetStatus) return status;
+        }
+        throw new IllegalStateException("Can not find verifiable status of permission named \"" + permissionUnit.getName() + "\"");
+    }
+
+    private List<PermissionDto> convertMapToList(Map<String, PermissionDto> permissionDtoMap){
+        List<PermissionDto> permissionDtoList = new ArrayList<>();
+        for(Map.Entry<String, PermissionDto> entry : permissionDtoMap.entrySet()){
+            permissionDtoList.add(entry.getValue());
+        }
+        return permissionDtoList;
     }
 
     @Override
@@ -78,11 +130,13 @@ public class DefaultCharacterManager implements CharacterManager{
         return false;
     }
 
-
     @Autowired
-    private DefaultCharacterManager(CharacterRepository characterRepository, PermissionChecker permissionChecker){
+    private DefaultCharacterManager(CharacterRepository characterRepository,
+            PermissionChecker permissionChecker,
+            PermissionUnitListReadable permissionUnitListReadable){
         this.characterRepository = characterRepository;
         this.permissionChecker = permissionChecker;
+        this.permissionUnitListReadable = permissionUnitListReadable;
     }
 
 }


### PR DESCRIPTION
- 기존에 Character생성시 permission이 비어있으면, 해당 permission을 지정해주지 않았는데,
- 이제부터는 permission이 비어있으면 비어있는 permission은 항상 실패하는 permission으로 지정해줌