### PR TITLE
refactor : user 도메인의 상, 벌점을 원시타입에서 객체로 바꿈

### DIFF
--- a/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/point/Advantage.java
+++ b/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/point/Advantage.java
@@ -2,20 +2,14 @@ package org.waldreg.domain.point;
 
 import java.time.LocalDateTime;
 
-public final class Advantage implements Point{
-
-    private final String advantageInfo;
-    private final LocalDateTime advantagePresentedAt;
-    private final int advantagePoint;
+public final class Advantage extends Point{
 
     private Advantage(){
         throw new UnsupportedOperationException("Can not invoke constructor \"Advantage()\"");
     }
 
     public Advantage(PointBuilder<Advantage> builder){
-        this.advantageInfo = builder.info;
-        this.advantagePresentedAt = builder.presentedAt;
-        this.advantagePoint = builder.point;
+        super(builder);
     }
 
     public static PointBuilder<Advantage> builder(){
@@ -25,18 +19,6 @@ public final class Advantage implements Point{
                 return new Advantage(this);
             }
         };
-    }
-
-    public String getAdvantageInfo(){
-        return advantageInfo;
-    }
-
-    public LocalDateTime getAdvantagePresentedAt(){
-        return advantagePresentedAt;
-    }
-
-    public int getAdvantagePoint(){
-        return advantagePoint;
     }
 
 }

--- a/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/point/Penalty.java
+++ b/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/point/Penalty.java
@@ -1,21 +1,13 @@
 package org.waldreg.domain.point;
 
-import java.time.LocalDateTime;
-
-public final class Penalty implements Point{
-
-    private final String penaltyInfo;
-    private final LocalDateTime penaltyPresentedAt;
-    private final int penaltyPoint;
+public final class Penalty extends Point{
 
     private Penalty(){
         throw new UnsupportedOperationException("Can not invoke constructor \"Penalty()\"");
     }
 
     public Penalty(PointBuilder<Penalty> builder){
-        this.penaltyInfo = builder.info;
-        this.penaltyPresentedAt = builder.presentedAt;
-        this.penaltyPoint = builder.point;
+        super(builder);
     }
 
     public static PointBuilder<Penalty> builder(){
@@ -25,18 +17,6 @@ public final class Penalty implements Point{
                 return new Penalty(this);
             }
         };
-    }
-
-    public String getPenaltyInfo(){
-        return penaltyInfo;
-    }
-
-    public LocalDateTime getPenaltyPresentedAt(){
-        return penaltyPresentedAt;
-    }
-
-    public int getPenaltyPoint(){
-        return penaltyPoint;
     }
 
 }

--- a/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/point/Point.java
+++ b/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/point/Point.java
@@ -2,9 +2,35 @@ package org.waldreg.domain.point;
 
 import java.time.LocalDateTime;
 
-public interface Point{
+public abstract class Point{
 
-    abstract class PointBuilder<R extends Point>{
+    private final String pointInfo;
+    private final LocalDateTime pointPresentedAt;
+    private final int point;
+
+    Point(){
+        throw new UnsupportedOperationException("Can not invoke constructor \"Point()\"");
+    }
+
+    public Point(PointBuilder<? extends Point> builder){
+        this.pointInfo = builder.info;
+        this.pointPresentedAt = builder.presentedAt;
+        this.point = builder.point;
+    }
+
+    public String getPointInfo(){
+        return this.pointInfo;
+    }
+
+    public LocalDateTime getPointPresentedAt(){
+        return this.pointPresentedAt;
+    }
+
+    public int getPoint(){
+        return this.point;
+    }
+
+    public abstract static class PointBuilder<R extends Point>{
 
         String info;
         LocalDateTime presentedAt;

--- a/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/user/User.java
+++ b/waldreg/domain-layer/domain/src/main/java/org/waldreg/domain/user/User.java
@@ -1,9 +1,13 @@
 package org.waldreg.domain.user;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.waldreg.domain.character.Character;
+import org.waldreg.domain.point.Advantage;
+import org.waldreg.domain.point.Penalty;
+import org.waldreg.domain.point.Point;
 
 @SuppressWarnings("unused")
 public final class User{
@@ -14,8 +18,8 @@ public final class User{
     private String userPassword;
     private String phoneNumber;
     private final LocalDate createdAt;
-    private final int advantage;
-    private final int penalty;
+    private final Point advantage;
+    private final Point penalty;
     private Character character;
     private List<String> socialLogin;
 
@@ -72,11 +76,11 @@ public final class User{
         return createdAt;
     }
 
-    public int getAdvantage(){
+    public Point getAdvantage(){
         return advantage;
     }
 
-    public int getPenalty(){
+    public Point getPenalty(){
         return penalty;
     }
 
@@ -98,7 +102,6 @@ public final class User{
         this.character = character;
     }
 
-    @SuppressWarnings("unused")
     public final static class Builder{
 
         private int id;
@@ -107,14 +110,22 @@ public final class User{
         private String userPassword;
         private String phoneNumber;
         private final LocalDate createdAt;
-        private final int advantage;
-        private final int penalty;
+        private final Point advantage;
+        private final Point penalty;
         private List<String> socialLogin;
 
         {
             createdAt = LocalDate.now();
-            advantage = 0;
-            penalty = 0;
+            advantage = Advantage.builder()
+                    .point(0)
+                    .info("")
+                    .presentedAt(LocalDateTime.now())
+                    .build();
+            penalty = Penalty.builder()
+                    .point(0)
+                    .info("")
+                    .presentedAt(LocalDateTime.now())
+                    .build();
             socialLogin = new ArrayList<>();
         }
 

--- a/waldreg/repository-layer/memory-repository/src/main/java/org/waldreg/repository/user/MemoryUserRepository.java
+++ b/waldreg/repository-layer/memory-repository/src/main/java/org/waldreg/repository/user/MemoryUserRepository.java
@@ -61,7 +61,10 @@ public class MemoryUserRepository implements UserRepository{
 
     @Override
     public void updateUser(int id, UserDto userDto){
-        User user = userMapper.userDtoToUserDomain(userDto);
+        User user = memoryUserStorage.readUserById(id);
+        user.setUserPassword(userDto.getUserPassword());
+        user.setPhoneNumber(userDto.getPhoneNumber());
+        user.setName(userDto.getName());
         memoryUserStorage.updateUser(id, user);
     }
 

--- a/waldreg/repository-layer/memory-repository/src/main/java/org/waldreg/repository/user/UserMapper.java
+++ b/waldreg/repository-layer/memory-repository/src/main/java/org/waldreg/repository/user/UserMapper.java
@@ -26,8 +26,8 @@ public class UserMapper{
                 .userPassword(user.getUserPassword())
                 .phoneNumber(user.getPhoneNumber())
                 .createdAt(user.getCreatedAt())
-                .advantage(user.getAdvantage())
-                .penalty(user.getPenalty())
+                .advantage(user.getAdvantage().getPoint())
+                .penalty(user.getPenalty().getPoint())
                 .character(user.getCharacter().getCharacterName())
                 .socialLogin(user.getSocialLogin())
                 .build();


### PR DESCRIPTION
- user 도메인의 상, 벌점을 원시타입에서 객체로 바꿨습니다.
- userMapper 의 domainToDto로직과 updateUser로직을 상, 벌점을 초기화 하지않도록 변경 했습니다.