### PR TITLE
fix : reward tag의 제목과 점수가 각각 100, -1000~1000 을 초과하지 않도록 변경함

### DIFF
--- a/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
+++ b/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
@@ -4,26 +4,62 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.wadlreg.reward.tag.dto.RewardTagDto;
+import org.wadlreg.reward.tag.lib.TagExceedClipper;
 import org.wadlreg.reward.tag.spi.RewardTagRepository;
 
 @Service
 public class DefaultRewardTagManager implements RewardTagManager{
 
     private final RewardTagRepository rewardTagRepository;
+    private final TagExceedClipper tagExceedClipper;
+    private final int maxTagTitleLength;
+    private final int minTagPoint;
+    private final int maxTagPoint;
 
     @Autowired
-    public DefaultRewardTagManager(RewardTagRepository rewardTagRepository){
+    public DefaultRewardTagManager(RewardTagRepository rewardTagRepository, TagExceedClipper tagExceedClipper){
         this.rewardTagRepository = rewardTagRepository;
+        this.tagExceedClipper = tagExceedClipper;
+        this.maxTagTitleLength = 100;
+        this.minTagPoint = -1000;
+        this.maxTagPoint = 1000;
     }
 
     @Override
     public void createRewardTag(RewardTagDto rewardTagDto){
+        rewardTagDto = clipRewardTagDto(rewardTagDto);
+        throwIfRewardTagDtoExceedRange(rewardTagDto);
         rewardTagRepository.createRewardTag(rewardTagDto);
     }
 
     @Override
     public void updateRewardTag(int rewardTagId, RewardTagDto rewardTagDto){
         rewardTagRepository.updateRewardTag(rewardTagId, rewardTagDto);
+    }
+
+    private RewardTagDto clipRewardTagDto(RewardTagDto rewardTagDto){
+        return RewardTagDto.builder()
+                .rewardTagTitle(tagExceedClipper.clipTagTitle(rewardTagDto.getRewardTagTitle()))
+                .rewardPoint(tagExceedClipper.clipTagPoint(rewardTagDto.getRewardPoint()))
+                .build();
+    }
+
+    private void throwIfRewardTagDtoExceedRange(RewardTagDto rewardTagDto){
+        throwIfRewardTagDtoTitleExceedRange(rewardTagDto);
+        throwIfRewardTagDtoPointExceedRange(rewardTagDto);
+    }
+
+    private void throwIfRewardTagDtoTitleExceedRange(RewardTagDto rewardTagDto){
+        if(rewardTagDto.getRewardTagTitle().length() > this.maxTagTitleLength){
+            throw new IllegalStateException("Reward Tag Dto's title exceed range \"" + rewardTagDto.getRewardTagTitle().length() + "\"");
+        }
+    }
+
+    private void throwIfRewardTagDtoPointExceedRange(RewardTagDto rewardTagDto){
+        if(rewardTagDto.getRewardPoint() < this.minTagPoint
+            || rewardTagDto.getRewardPoint() > this.maxTagPoint){
+            throw new IllegalStateException("Reward Tag Dto's point exceed range \"" + rewardTagDto.getRewardPoint() + "\"");
+        }
     }
 
     @Override

--- a/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
+++ b/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
@@ -34,6 +34,8 @@ public class DefaultRewardTagManager implements RewardTagManager{
 
     @Override
     public void updateRewardTag(int rewardTagId, RewardTagDto rewardTagDto){
+        rewardTagDto = clipRewardTagDto(rewardTagDto);
+        throwIfRewardTagDtoExceedRange(rewardTagDto);
         rewardTagRepository.updateRewardTag(rewardTagId, rewardTagDto);
     }
 

--- a/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/lib/TagExceedClipper.java
+++ b/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/lib/TagExceedClipper.java
@@ -5,9 +5,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class TagExceedClipper{
 
-    private final int maxTagTitleLength = 100;
-    private final int minTagPoint = -1000;
-    private final int maxTagPoint = 1000;
+    private final int maxTagTitleLength;
+    private final int minTagPoint;
+    private final int maxTagPoint;
+
+    public TagExceedClipper(){
+        this.maxTagTitleLength = 100;
+        this.minTagPoint = -1000;
+        this.maxTagPoint = 1000;
+    }
 
     public String clipTagTitle(String title){
         if(title.length() <= maxTagTitleLength) return title;

--- a/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
+++ b/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
@@ -13,10 +13,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.wadlreg.reward.tag.DefaultRewardTagManager;
 import org.wadlreg.reward.tag.RewardTagManager;
 import org.wadlreg.reward.tag.dto.RewardTagDto;
+import org.wadlreg.reward.tag.lib.TagExceedClipper;
 import org.wadlreg.reward.tag.spi.RewardTagRepository;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {DefaultRewardTagManager.class})
+@ContextConfiguration(classes = {DefaultRewardTagManager.class, TagExceedClipper.class})
 public class RewardTagManagerTest{
 
     @Autowired
@@ -31,6 +32,21 @@ public class RewardTagManagerTest{
         // given
         String rewardTagTitle = "hello reward";
         int rewardPoint = 10;
+        RewardTagDto rewardTagDto = RewardTagDto.builder()
+                .rewardTagTitle(rewardTagTitle)
+                .rewardPoint(rewardPoint)
+                .build();
+
+        // when & then
+        Assertions.assertDoesNotThrow(() -> rewardTagManager.createRewardTag(rewardTagDto));
+    }
+
+    @Test
+    @DisplayName("새로운 RewardTag 생성 성공 테스트 - 경계 강제 조정")
+    public void CREATE_NEW_REWARD_TAG_SUCCESS_MODIFY_EXCEED_BORDER_TEST(){
+        // given
+        String rewardTagTitle = "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 ";
+        int rewardPoint = 10000;
         RewardTagDto rewardTagDto = RewardTagDto.builder()
                 .rewardTagTitle(rewardTagTitle)
                 .rewardPoint(rewardPoint)

--- a/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
+++ b/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
@@ -72,6 +72,21 @@ public class RewardTagManagerTest{
     }
 
     @Test
+    @DisplayName("RewardTag 업데이트 성공 테스트 - 경계 강제 조정")
+    public void UPDATE_REWARD_TAG_SUCCESS_MODIFY_EXCEED_BORDER_TEST(){
+        // given
+        String rewardTagTitle = "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 ";
+        int rewardPoint = 10000;
+        RewardTagDto rewardTagDto = RewardTagDto.builder()
+                .rewardTagTitle(rewardTagTitle)
+                .rewardPoint(rewardPoint)
+                .build();
+
+        // when & then
+        Assertions.assertDoesNotThrow(() -> rewardTagManager.updateRewardTag(1, rewardTagDto));
+    }
+
+    @Test
     @DisplayName("RewardTag 삭제 삭제 성공 테스트")
     public void DELETE_REWARD_TAG_SUCCESS_TEST(){
         // given


### PR DESCRIPTION
- reward tag의 제목과 점수가 각각 100, (-1000~1000)을 초과하지 않도록 변경했습니다.