### PR TITLE
fix : reward tag 업데이트시 tag를 찾을 수 없으면 예외를 반환하도록 수정

### DIFF
--- a/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
+++ b/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
@@ -41,6 +41,12 @@ public class DefaultRewardTagManager implements RewardTagManager{
         rewardTagRepository.updateRewardTag(rewardTagId, rewardTagDto);
     }
 
+    @Override
+    public void deleteRewardTag(int rewardTagId){
+        throwIfCannotFindRewardByRewardTagId(rewardTagId);
+        rewardTagRepository.deleteRewardTag(rewardTagId);
+    }
+
     private void throwIfCannotFindRewardByRewardTagId(int rewardTagId){
         List<RewardTagDto> rewardTagDtoList = rewardTagRepository.readRewardTagList();
         for(RewardTagDto rewardTagDto : rewardTagDtoList){
@@ -74,11 +80,6 @@ public class DefaultRewardTagManager implements RewardTagManager{
             || rewardTagDto.getRewardPoint() > this.maxTagPoint){
             throw new IllegalStateException("Reward Tag Dto's point exceed range \"" + rewardTagDto.getRewardPoint() + "\"");
         }
-    }
-
-    @Override
-    public void deleteRewardTag(int rewardTagId){
-        rewardTagRepository.deleteRewardTag(rewardTagId);
     }
 
     @Override

--- a/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
+++ b/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/DefaultRewardTagManager.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.wadlreg.reward.tag.dto.RewardTagDto;
+import org.wadlreg.reward.tag.exception.UnknownRewardTagException;
 import org.wadlreg.reward.tag.lib.TagExceedClipper;
 import org.wadlreg.reward.tag.spi.RewardTagRepository;
 
@@ -34,9 +35,20 @@ public class DefaultRewardTagManager implements RewardTagManager{
 
     @Override
     public void updateRewardTag(int rewardTagId, RewardTagDto rewardTagDto){
+        throwIfCannotFindRewardByRewardTagId(rewardTagId);
         rewardTagDto = clipRewardTagDto(rewardTagDto);
         throwIfRewardTagDtoExceedRange(rewardTagDto);
         rewardTagRepository.updateRewardTag(rewardTagId, rewardTagDto);
+    }
+
+    private void throwIfCannotFindRewardByRewardTagId(int rewardTagId){
+        List<RewardTagDto> rewardTagDtoList = rewardTagRepository.readRewardTagList();
+        for(RewardTagDto rewardTagDto : rewardTagDtoList){
+            if(rewardTagDto.getRewardTagId() == rewardTagId) {
+                return;
+            }
+        }
+        throw new UnknownRewardTagException(rewardTagId);
     }
 
     private RewardTagDto clipRewardTagDto(RewardTagDto rewardTagDto){

--- a/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/exception/UnknownRewardTagException.java
+++ b/waldreg/service-layer/reward/src/main/java/org/wadlreg/reward/tag/exception/UnknownRewardTagException.java
@@ -1,0 +1,9 @@
+package org.wadlreg.reward.tag.exception;
+
+public class UnknownRewardTagException extends RuntimeException{
+
+    public UnknownRewardTagException(int id){
+        super("Unknown reward tag id \"" + id + "\"");
+    }
+
+}

--- a/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
+++ b/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
@@ -67,7 +67,10 @@ public class RewardTagManagerTest{
                 .rewardPoint(rewardPoint)
                 .build();
 
-        // when & then
+        // when
+        Mockito.when(rewardTagRepository.readRewardTagList()).thenReturn(List.of(RewardTagDto.builder().rewardTagId(1).build()));
+
+        // then
         Assertions.assertDoesNotThrow(() -> rewardTagManager.updateRewardTag(1, rewardTagDto));
     }
 
@@ -82,7 +85,28 @@ public class RewardTagManagerTest{
                 .rewardPoint(rewardPoint)
                 .build();
 
-        // when & then
+        // when
+        Mockito.when(rewardTagRepository.readRewardTagList()).thenReturn(List.of(RewardTagDto.builder().rewardTagId(1).build()));
+
+        // then
+        Assertions.assertDoesNotThrow(() -> rewardTagManager.updateRewardTag(1, rewardTagDto));
+    }
+
+    @Test
+    @DisplayName("RewardTag 업데이트 실패 테스트 - reward tag id에 해당하는 reward tag를 찾을 수 없음")
+    public void UPDATE_REWARD_TAG_FAIL_UNKNOWN_REWARD_TAG_ID_TEST(){
+        // given
+        String rewardTagTitle = "hello reward";
+        int rewardPoint = 10;
+        RewardTagDto rewardTagDto = RewardTagDto.builder()
+                .rewardTagTitle(rewardTagTitle)
+                .rewardPoint(rewardPoint)
+                .build();
+
+        // when
+        Mockito.when(rewardTagRepository.readRewardTagList()).thenReturn(List.of(RewardTagDto.builder().rewardTagId(1).build()));
+
+        // then
         Assertions.assertDoesNotThrow(() -> rewardTagManager.updateRewardTag(1, rewardTagDto));
     }
 
@@ -93,7 +117,7 @@ public class RewardTagManagerTest{
         int rewardTagId = 1;
 
         // when & then
-        Assertions.assertDoesNotThrow(()->rewardTagManager.deleteRewardTag(rewardTagId));
+        Assertions.assertDoesNotThrow(() -> rewardTagManager.deleteRewardTag(rewardTagId));
     }
 
     @Test
@@ -114,17 +138,16 @@ public class RewardTagManagerTest{
                 .rewardPoint(rewardPoint2)
                 .build();
 
-
         // when
         Mockito.when(rewardTagRepository.readRewardTagList()).thenReturn(List.of(rewardTagDto, rewardTagDto2));
         List<RewardTagDto> rewardTagDtoList = rewardTagRepository.readRewardTagList();
 
         // then
         Assertions.assertAll(
-                ()-> Assertions.assertEquals(rewardTagDtoList.get(0).getRewardTagTitle(), rewardTagTitle),
-                ()-> Assertions.assertEquals(rewardTagDtoList.get(0).getRewardPoint(), rewardPoint),
-                ()-> Assertions.assertEquals(rewardTagDtoList.get(1).getRewardTagTitle(), rewardTagTitle2),
-                ()-> Assertions.assertEquals(rewardTagDtoList.get(1).getRewardPoint(), rewardPoint2)
+                () -> Assertions.assertEquals(rewardTagDtoList.get(0).getRewardTagTitle(), rewardTagTitle),
+                () -> Assertions.assertEquals(rewardTagDtoList.get(0).getRewardPoint(), rewardPoint),
+                () -> Assertions.assertEquals(rewardTagDtoList.get(1).getRewardTagTitle(), rewardTagTitle2),
+                () -> Assertions.assertEquals(rewardTagDtoList.get(1).getRewardPoint(), rewardPoint2)
         );
     }
 

--- a/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
+++ b/waldreg/service-layer/reward/src/test/java/org/waldreg/reward/tag/RewardTagManagerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.wadlreg.reward.tag.DefaultRewardTagManager;
 import org.wadlreg.reward.tag.RewardTagManager;
 import org.wadlreg.reward.tag.dto.RewardTagDto;
+import org.wadlreg.reward.tag.exception.UnknownRewardTagException;
 import org.wadlreg.reward.tag.lib.TagExceedClipper;
 import org.wadlreg.reward.tag.spi.RewardTagRepository;
 
@@ -116,8 +117,21 @@ public class RewardTagManagerTest{
         // given
         int rewardTagId = 1;
 
-        // when & then
+        // when
+        Mockito.when(rewardTagRepository.readRewardTagList()).thenReturn(List.of(RewardTagDto.builder().rewardTagId(1).build()));
+
+        // then
         Assertions.assertDoesNotThrow(() -> rewardTagManager.deleteRewardTag(rewardTagId));
+    }
+
+    @Test
+    @DisplayName("RewardTag 삭제 실패 테스트 - rewardTagId에 해당하는 rewardTag를 찾을 수 없음")
+    public void DELETE_REWARD_TAG_FAIL_UNKNOWN_REWARD_TAG_TEST(){
+        // given
+        int rewardTagId = 1;
+
+        // when & then
+        Assertions.assertThrows(UnknownRewardTagException.class, () -> rewardTagManager.deleteRewardTag(rewardTagId));
     }
 
     @Test


### PR DESCRIPTION
- reward tag 업데이트시 tag를 찾을 수 없으면
- UnknownRewardTagException.class 예외를 반환하도록 수정했습니다.