### PR TITLE
test : Category 삭제 시 Category의 BoardList에 있던 Board도 함께 삭제

### DIFF
--- a/waldreg/repository-layer/memory-repository/src/main/java/org/waldreg/repository/category/MemoryCategoryRepository.java
+++ b/waldreg/repository-layer/memory-repository/src/main/java/org/waldreg/repository/category/MemoryCategoryRepository.java
@@ -8,6 +8,7 @@ import org.waldreg.board.dto.BoardDto;
 import org.waldreg.board.dto.CategoryDto;
 import org.waldreg.domain.board.Board;
 import org.waldreg.domain.category.Category;
+import org.waldreg.repository.MemoryBoardStorage;
 import org.waldreg.repository.MemoryCategoryStorage;
 
 @Repository
@@ -15,11 +16,14 @@ public class MemoryCategoryRepository implements CategoryRepository{
 
     private final MemoryCategoryStorage memoryCategoryStorage;
 
+    private final MemoryBoardStorage memoryBoardStorage;
+
     private final CategoryMapper categoryMapper;
 
     @Autowired
-    public MemoryCategoryRepository(MemoryCategoryStorage memoryCategoryStorage, CategoryMapper categoryMapper){
+    public MemoryCategoryRepository(MemoryCategoryStorage memoryCategoryStorage, MemoryBoardStorage memoryBoardStorage, CategoryMapper categoryMapper){
         this.memoryCategoryStorage = memoryCategoryStorage;
+        this.memoryBoardStorage = memoryBoardStorage;
         this.categoryMapper = categoryMapper;
     }
 
@@ -61,7 +65,15 @@ public class MemoryCategoryRepository implements CategoryRepository{
 
     @Override
     public void deleteCategory(int id){
+        Category category = memoryCategoryStorage.inquiryCategoryById(id);
+        deleteBoardInCategoryBoardList(category.getBoardList());
         memoryCategoryStorage.deleteCategory(id);
+    }
+
+    private void deleteBoardInCategoryBoardList(List<Board> boardList){
+        for(Board board : boardList){
+            memoryBoardStorage.deleteBoardById(board.getId());
+        }
     }
 
     @Override

--- a/waldreg/repository-layer/memory-repository/src/test/java/org/waldreg/repository/category/CategoryRepositoryTest.java
+++ b/waldreg/repository-layer/memory-repository/src/test/java/org/waldreg/repository/category/CategoryRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.waldreg.repository.category;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -16,6 +17,7 @@ import org.waldreg.board.category.spi.CategoryRepository;
 import org.waldreg.board.dto.BoardDto;
 import org.waldreg.board.dto.CategoryDto;
 import org.waldreg.board.dto.UserDto;
+import org.waldreg.character.dto.CharacterDto;
 import org.waldreg.character.spi.CharacterRepository;
 import org.waldreg.repository.MemoryBoardStorage;
 import org.waldreg.repository.MemoryCategoryStorage;
@@ -132,18 +134,56 @@ public class CategoryRepositoryTest{
     @DisplayName("카테고리 삭제 성공 테스트")
     public void DELETE_CATEGORY_BY_ID_SUCCESS_TEST(){
         //given
-        String categoryName = "catecate";
-        CategoryDto categoryDto = CategoryDto.builder()
-                .categoryName(categoryName)
+        org.waldreg.user.dto.UserDto user = org.waldreg.user.dto.UserDto.builder()
+                .userId("alcuk_id")
+                .name("alcuk")
+                .userPassword("alcuk123!")
+                .phoneNumber("010-1234-1234")
                 .build();
+        CharacterDto characterDto = CharacterDto.builder()
+                .id(1)
+                .characterName("Guest")
+                .permissionDtoList(List.of())
+                .build();
+        characterRepository.createCharacter(characterDto);
+        userRepository.createUser(user);
+        org.waldreg.user.dto.UserDto userResponse = userRepository.readUserByUserId("alcuk_id");
+        String title = "title";
+        String content = "content";
+        UserDto userDto = UserDto.builder()
+                .id(userResponse.getId())
+                .userId("alcuk_id")
+                .name("alcuk")
+                .build();
+        CategoryDto categoryDto = CategoryDto.builder()
+                .categoryName("cate")
+                .build();
+        List<String> filePathList = new ArrayList<>();
+        filePathList.add("uuid.pptx");
+        List<String> imagePathList = new ArrayList<>();
+        imagePathList.add("uuid.png");
 
         //when
         categoryRepository.createCategory(categoryDto);
-        CategoryDto categoryResponse = categoryRepository.inquiryAllCategory().get(0);
-        categoryRepository.deleteCategory(categoryResponse.getId());
+        int categoryId = categoryRepository.inquiryAllCategory().get(0).getId();
+        BoardDto boardRequest = BoardDto.builder()
+                .title(title)
+                .userDto(userDto)
+                .content(content)
+                .categoryId(categoryId)
+                .lastModifiedAt(LocalDateTime.now())
+                .fileUrls(filePathList)
+                .imageUrls(imagePathList)
+                .build();
+        BoardDto boardDto = boardRepository.createBoard(boardRequest);
+        categoryRepository.addBoardInCategoryBoardList(boardDto);
+        categoryRepository.deleteCategory(categoryId);
 
         //then
-        Assertions.assertFalse(() -> categoryRepository.isExistCategory(categoryResponse.getId()));
+        Assertions.assertAll(
+                () -> Assertions.assertFalse(() -> categoryRepository.isExistCategory(categoryId)),
+                () -> Assertions.assertFalse(() -> boardRepository.isExistBoard(boardDto.getId()))
+        );
     }
 
     @Test


### PR DESCRIPTION
성공 레포지토리 테스트

- Category 삭제 시 Category domain의 BoardList에 있던 Board들도 함께 삭제되도록 로직 추가함