### PR TITLE
feat : 새로운 팀빌딩 생성 서비스 예외 처리

### DIFF
--- a/waldreg/service-layer/schedule/src/main/java/org/waldreg/schedule/exception/InvalidDateFormatException.java
+++ b/waldreg/service-layer/schedule/src/main/java/org/waldreg/schedule/exception/InvalidDateFormatException.java
@@ -6,7 +6,7 @@ public final class InvalidDateFormatException extends RuntimeException{
 
     public InvalidDateFormatException(String code, String message){
         super(message);
-        this.code=code;
+        this.code = code;
     }
 
     public String getCode(){

--- a/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/exception/ContentOverflowException.java
+++ b/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/exception/ContentOverflowException.java
@@ -1,0 +1,14 @@
+package org.waldreg.teambuilding.exception;
+
+public class ContentOverflowException extends RuntimeException{
+
+    private final String code;
+
+    public ContentOverflowException(String code, String message){
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode(){return code;}
+
+}

--- a/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/exception/InvalidTeamCountException.java
+++ b/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/exception/InvalidTeamCountException.java
@@ -1,0 +1,16 @@
+package org.waldreg.teambuilding.exception;
+
+public class InvalidTeamCountException extends RuntimeException{
+
+    private final String code;
+
+    public InvalidTeamCountException(String code, String message){
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode(){
+        return code;
+    }
+
+}

--- a/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/exception/InvalidUserWeightException.java
+++ b/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/exception/InvalidUserWeightException.java
@@ -1,0 +1,7 @@
+package org.waldreg.teambuilding.exception;
+
+public class InvalidUserWeightException extends RuntimeException{
+
+    public InvalidUserWeightException(int weight){super("User’s weight value should be between 1 and 10, current weight \""+weight+"\"");}
+
+}

--- a/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/management/DefaultTeamBuildingManager.java
+++ b/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/management/DefaultTeamBuildingManager.java
@@ -10,6 +10,9 @@ import org.waldreg.teambuilding.dto.TeamBuildingRequestDto;
 import org.waldreg.teambuilding.dto.TeamDto;
 import org.waldreg.teambuilding.dto.UserDto;
 import org.waldreg.teambuilding.dto.UserRequestDto;
+import org.waldreg.teambuilding.exception.ContentOverflowException;
+import org.waldreg.teambuilding.exception.InvalidTeamCountException;
+import org.waldreg.teambuilding.exception.InvalidUserWeightException;
 import org.waldreg.teambuilding.management.teamcreator.TeamCreator;
 import org.waldreg.teambuilding.management.teamcreator.TeamCreator.Team;
 import org.waldreg.teambuilding.spi.TeamBuildingRepository;
@@ -39,26 +42,47 @@ public class DefaultTeamBuildingManager implements TeamBuildingManager{
 
     @Override
     public void createTeamBuilding(TeamBuildingRequestDto teamBuildingRequestDto){
-        List<TeamDto> teamDtoList = createTeamDtoList(teamBuildingRequestDto.getUserList(), teamBuildingRequestDto.getTeamCount());
-        TeamBuildingDto teamBuildingDto = buildTeamBuildingDto(teamBuildingRequestDto.getTeamBuildingTitle(), teamDtoList);
+        String teamBuildingTitle = teamBuildingRequestDto.getTeamBuildingTitle();
+        int teamCount = teamBuildingRequestDto.getTeamCount();
+        List<UserRequestDto> userRequestDtoList = teamBuildingRequestDto.getUserList();
+        throwIfTeamBuildingTitleIsOverflow(teamBuildingTitle);
+        throwIfTeamCountIsLessThanOrEqualToZero(teamCount);
+        throwIfTeamCountExceedMemberCount(teamCount, userRequestDtoList.size());
+        throwIfUserWeightIsOutOfRange(userRequestDtoList);
+        List<TeamDto> teamDtoList = createTeamDtoList(userRequestDtoList, teamCount);
+        TeamBuildingDto teamBuildingDto = buildTeamBuildingDto(teamBuildingTitle, teamDtoList);
         teamBuildingRepository.createTeamBuilding(teamBuildingDto);
     }
 
-    @Override
-    public List<TeamBuildingDto> readAllTeamBuilding(int startIdx, int endIdx){
-        return teamBuildingRepository.readAllTeamBuilding(startIdx, endIdx);
+    private void throwIfTeamBuildingTitleIsOverflow(String teamBuildingTitle){
+        int length = teamBuildingTitle.length();
+        if (length > 1000){
+            throw new ContentOverflowException("TEAMBUILDING-401", "Teambuilding title cannot be more than 1000 current length \"" + length + "\"");
+        }
     }
 
-    @Override
-    public void updateTeamBuildingTitleById(int teamBuildingId, String teamBuildingTitle){
-        TeamBuildingDto teamBuildingDto = teamBuildingRepository.readTeamBuildingById(teamBuildingId);
-        teamBuildingDto.setTeamBuildingTitle(teamBuildingTitle);
-        teamBuildingRepository.updateTeamBuildingTitleById(teamBuildingId, teamBuildingDto);
+    private void throwIfTeamCountIsLessThanOrEqualToZero(int teamCount){
+        if (teamCount <= 0){
+            throw new InvalidTeamCountException("TEAMBUILDING-402", "The number of team cannot be less than or equal to zero, current team count \"" + teamCount + "\"");
+        }
     }
 
-    @Override
-    public void deleteTeamBuildingById(int teamBuildingId){
-        teamBuildingRepository.deleteTeamBuildingById(teamBuildingId);
+    private void throwIfTeamCountExceedMemberCount(int teamCount, int memberCount){
+        if (teamCount > memberCount){
+            throw new InvalidTeamCountException("TEAMBUILDING-410", "Team count \"" + teamCount + "\" cannot exceed member count \"" + memberCount + "\"");
+        }
+    }
+
+    private void throwIfUserWeightIsOutOfRange(List<UserRequestDto> userRequestDtoList){
+        for (UserRequestDto userRequestDto : userRequestDtoList){
+            if (!isUserWeightInRange(userRequestDto.getWeight())){
+                throw new InvalidUserWeightException(userRequestDto.getWeight());
+            }
+        }
+    }
+
+    private boolean isUserWeightInRange(int weight){
+        return weight >= 1 && weight <= 10;
     }
 
     private List<TeamDto> createTeamDtoList(List<UserRequestDto> userRequestDtoList, int teamCount){
@@ -93,6 +117,23 @@ public class DefaultTeamBuildingManager implements TeamBuildingManager{
                 .teamBuildingTitle(title)
                 .teamDtoList(teamDtoList)
                 .build();
+    }
+
+    @Override
+    public List<TeamBuildingDto> readAllTeamBuilding(int startIdx, int endIdx){
+        return teamBuildingRepository.readAllTeamBuilding(startIdx, endIdx);
+    }
+
+    @Override
+    public void updateTeamBuildingTitleById(int teamBuildingId, String teamBuildingTitle){
+        TeamBuildingDto teamBuildingDto = teamBuildingRepository.readTeamBuildingById(teamBuildingId);
+        teamBuildingDto.setTeamBuildingTitle(teamBuildingTitle);
+        teamBuildingRepository.updateTeamBuildingTitleById(teamBuildingId, teamBuildingDto);
+    }
+
+    @Override
+    public void deleteTeamBuildingById(int teamBuildingId){
+        teamBuildingRepository.deleteTeamBuildingById(teamBuildingId);
     }
 
 }

--- a/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/teambuilding/TeamBuildingServiceTest.java
+++ b/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/teambuilding/TeamBuildingServiceTest.java
@@ -17,6 +17,9 @@ import org.waldreg.teambuilding.dto.TeamBuildingRequestDto;
 import org.waldreg.teambuilding.dto.TeamDto;
 import org.waldreg.teambuilding.dto.UserDto;
 import org.waldreg.teambuilding.dto.UserRequestDto;
+import org.waldreg.teambuilding.exception.ContentOverflowException;
+import org.waldreg.teambuilding.exception.InvalidTeamCountException;
+import org.waldreg.teambuilding.exception.InvalidUserWeightException;
 import org.waldreg.teambuilding.management.DefaultTeamBuildingManager;
 import org.waldreg.teambuilding.management.TeamBuildingManager;
 import org.waldreg.teambuilding.management.teamcreator.TeamCreator;
@@ -53,8 +56,80 @@ public class TeamBuildingServiceTest{
                 .userRequestDtoList(userRequestDtoList)
                 .build();
 
-        //then
+        //when&then
         Assertions.assertDoesNotThrow(() -> teamBuildingManager.createTeamBuilding(teamBuildingRequestDto));
+
+    }
+
+    @Test
+    @DisplayName("새로운 팀빌딩 그룹 생성 실패 테스트 - teamBuildingTitle 길이 1000 초과")
+    public void CREATE_NEW_TEAM_BUILDING_FAIL_CAUSE_TEAM_BUILDING_TITLE_OVERFLOW_TEST(){
+        //given
+        String title = createOverflow();
+        int teamCount = 3;
+        List<UserRequestDto> userRequestDtoList = createUserRequestDtoList();
+        TeamBuildingRequestDto teamBuildingRequestDto = TeamBuildingRequestDto.builder()
+                .teamBuildingTitle(title)
+                .teamCount(teamCount)
+                .userRequestDtoList(userRequestDtoList)
+                .build();
+
+        //when&then
+        Assertions.assertThrows(ContentOverflowException.class, () -> teamBuildingManager.createTeamBuilding(teamBuildingRequestDto));
+
+    }
+
+    @Test
+    @DisplayName("새로운 팀빌딩 그룹 생성 실패 테스트 - 팀 개수가 0보다 작거나 같음")
+    public void CREATE_NEW_TEAM_BUILDING_FAIL_CAUSE_TEAM_COUNT_LESS_THAN_OR_EQUAL_TO_ZERO_TEST(){
+        //given
+        String title = "2nd Algorithm Contest Team";
+        int teamCount = 0;
+        List<UserRequestDto> userRequestDtoList = createUserRequestDtoList();
+        TeamBuildingRequestDto teamBuildingRequestDto = TeamBuildingRequestDto.builder()
+                .teamBuildingTitle(title)
+                .teamCount(teamCount)
+                .userRequestDtoList(userRequestDtoList)
+                .build();
+
+        //when&then
+        Assertions.assertThrows(InvalidTeamCountException.class , () -> teamBuildingManager.createTeamBuilding(teamBuildingRequestDto));
+
+    }
+
+    @Test
+    @DisplayName("새로운 팀빌딩 그룹 생성 실패 테스트 - 잘못된 user weight")
+    public void CREATE_NEW_TEAM_BUILDING_FAIL_CAUSE_INVALID_USER_WEIGHT_TEST(){
+        //given
+        String title = "2nd Algorithm Contest Team";
+        int teamCount = 3;
+        List<UserRequestDto> userRequestDtoList = createWrongUserRequestDtoList();
+        TeamBuildingRequestDto teamBuildingRequestDto = TeamBuildingRequestDto.builder()
+                .teamBuildingTitle(title)
+                .teamCount(teamCount)
+                .userRequestDtoList(userRequestDtoList)
+                .build();
+
+        //when&then
+        Assertions.assertThrows(InvalidUserWeightException.class, () -> teamBuildingManager.createTeamBuilding(teamBuildingRequestDto));
+
+    }
+
+    @Test
+    @DisplayName("새로운 팀빌딩 그룹 생성 실패 테스트 - 잘못된 team_count(userCount : 6)")
+    public void CREATE_NEW_TEAM_BUILDING_FAIL_CAUSE_INVALID_TEAM_COUNT_TEST(){
+        //given
+        String title = "2nd Algorithm Contest Team";
+        int teamCount = 10;
+        List<UserRequestDto> userRequestDtoList = createUserRequestDtoList();
+        TeamBuildingRequestDto teamBuildingRequestDto = TeamBuildingRequestDto.builder()
+                .teamBuildingTitle(title)
+                .teamCount(teamCount)
+                .userRequestDtoList(userRequestDtoList)
+                .build();
+
+        //when&then
+        Assertions.assertThrows(InvalidTeamCountException.class, () -> teamBuildingManager.createTeamBuilding(teamBuildingRequestDto));
 
     }
 
@@ -92,8 +167,8 @@ public class TeamBuildingServiceTest{
         teamBuildingDtoList.add(teamBuildingDto2);
 
         //when
-        Mockito.when(teamBuildingRepository.readAllTeamBuilding(Mockito.anyInt(),Mockito.anyInt())).thenReturn(teamBuildingDtoList);
-        List<TeamBuildingDto> result = teamBuildingManager.readAllTeamBuilding(1,2);
+        Mockito.when(teamBuildingRepository.readAllTeamBuilding(Mockito.anyInt(), Mockito.anyInt())).thenReturn(teamBuildingDtoList);
+        List<TeamBuildingDto> result = teamBuildingManager.readAllTeamBuilding(1, 2);
 
         //then
         Assertions.assertAll(
@@ -158,9 +233,9 @@ public class TeamBuildingServiceTest{
     private List<TeamDto> createTeamDtoList(int teamBuildingId){
         List<TeamDto> teamDtoList = new ArrayList<>();
         List<UserDto> userDtoList = createUserDtoList();
-        teamDtoList.add(createTeamDto(teamBuildingId, "team 1",List.of(userDtoList.get(0),userDtoList.get(2))));
-        teamDtoList.add(createTeamDto(teamBuildingId,"team 2",List.of(userDtoList.get(3),userDtoList.get(4))));
-        teamDtoList.add(createTeamDto(teamBuildingId, "team 3",List.of(userDtoList.get(1),userDtoList.get(5))));
+        teamDtoList.add(createTeamDto(teamBuildingId, "team 1", List.of(userDtoList.get(0), userDtoList.get(2))));
+        teamDtoList.add(createTeamDto(teamBuildingId, "team 2", List.of(userDtoList.get(3), userDtoList.get(4))));
+        teamDtoList.add(createTeamDto(teamBuildingId, "team 3", List.of(userDtoList.get(1), userDtoList.get(5))));
         return teamDtoList;
     }
 
@@ -202,6 +277,17 @@ public class TeamBuildingServiceTest{
         return userRequestDtoList;
     }
 
+    private List<UserRequestDto> createWrongUserRequestDtoList(){
+        List<UserRequestDto> userRequestDtoList = new ArrayList<>();
+        userRequestDtoList.add(createUserRequestDto("alcuk_id", 2));
+        userRequestDtoList.add(createUserRequestDto("alcuk_id2", 1));
+        userRequestDtoList.add(createUserRequestDto("alcuk_id3", 3));
+        userRequestDtoList.add(createUserRequestDto("alcuk_id4", 4));
+        userRequestDtoList.add(createUserRequestDto("alcuk_id5", -1));
+        userRequestDtoList.add(createUserRequestDto("alcuk_id6", 10));
+        return userRequestDtoList;
+    }
+
     private UserRequestDto createUserRequestDto(String userId, int weight){
         return UserRequestDto.builder()
                 .userId(userId)
@@ -209,5 +295,12 @@ public class TeamBuildingServiceTest{
                 .build();
     }
 
+    private String createOverflow(){
+        String title = "";
+        for (int i = 0; i < 1005; i++){
+            title = title + "A";
+        }
+        return title;
+    }
 
 }


### PR DESCRIPTION
- 새로운 팀빌딩 생성 실패 서비스 테스트 및 구현
- 팀빌딩 제목 길이 초과
- 팀 개수 0개 이하 설정
- 유저 가중치 범위 벗어남
- 팀 개수가 유저 수 초과