### PR TITLE
feat : 팀빌딩 수정 서비스 예외처리

### DIFF
--- a/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/management/DefaultTeamBuildingManager.java
+++ b/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/teambuilding/management/DefaultTeamBuildingManager.java
@@ -51,13 +51,6 @@ public class DefaultTeamBuildingManager implements TeamBuildingManager{
         teamBuildingRepository.createTeamBuilding(teamBuildingDto);
     }
 
-    private void throwIfTeamBuildingTitleIsOverflow(String teamBuildingTitle){
-        int length = teamBuildingTitle.length();
-        if (length > 1000){
-            throw new ContentOverflowException("TEAMBUILDING-401", "Teambuilding title cannot be more than 1000 current length \"" + length + "\"");
-        }
-    }
-
     private void throwIfTeamCountIsLessThanOrEqualToZero(int teamCount){
         if (teamCount <= 0){
             throw new InvalidTeamCountException("TEAMBUILDING-402", "The number of team cannot be less than or equal to zero, current team count \"" + teamCount + "\"");
@@ -122,12 +115,6 @@ public class DefaultTeamBuildingManager implements TeamBuildingManager{
         return teamBuildingRepository.readTeamBuildingById(teamBuildingId);
     }
 
-    private void throwIfUnknownTeamBuildingId(int teamBuildingId){
-        if (!teamBuildingRepository.isExistTeamBuilding(teamBuildingId)){
-            throw new UnknownTeamBuildingIdException(teamBuildingId);
-        }
-    }
-
     @Override
     public List<TeamBuildingDto> readAllTeamBuilding(int startIdx, int endIdx){
         int maxIdx = teamBuildingRepository.readMaxIdx();
@@ -164,9 +151,24 @@ public class DefaultTeamBuildingManager implements TeamBuildingManager{
 
     @Override
     public void updateTeamBuildingTitleById(int teamBuildingId, String teamBuildingTitle){
+        throwIfUnknownTeamBuildingId(teamBuildingId);
+        throwIfTeamBuildingTitleIsOverflow(teamBuildingTitle);
         TeamBuildingDto teamBuildingDto = teamBuildingRepository.readTeamBuildingById(teamBuildingId);
         teamBuildingDto.setTeamBuildingTitle(teamBuildingTitle);
         teamBuildingRepository.updateTeamBuildingTitleById(teamBuildingId, teamBuildingDto);
+    }
+
+    private void throwIfUnknownTeamBuildingId(int teamBuildingId){
+        if (!teamBuildingRepository.isExistTeamBuilding(teamBuildingId)){
+            throw new UnknownTeamBuildingIdException(teamBuildingId);
+        }
+    }
+
+    private void throwIfTeamBuildingTitleIsOverflow(String teamBuildingTitle){
+        int length = teamBuildingTitle.length();
+        if (length > 1000){
+            throw new ContentOverflowException("TEAMBUILDING-401", "Teambuilding title cannot be more than 1000 current length \"" + length + "\"");
+        }
     }
 
     @Override

--- a/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/teambuilding/TeamBuildingServiceTest.java
+++ b/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/teambuilding/TeamBuildingServiceTest.java
@@ -232,12 +232,12 @@ public class TeamBuildingServiceTest{
                 .teamBuildingTitle("modified Title")
                 .build();
         TeamBuildingDto teamBuildingDto2 = teamBuildingDto;
-        teamBuildingDto2.setTeamBuildingTitle(teamBuildingRequestDto.getTeamBuildingTitle());
 
         //when
         Mockito.when(teamBuildingRepository.isExistTeamBuilding(Mockito.anyInt())).thenReturn(true);
         Mockito.when(teamBuildingRepository.readTeamBuildingById(Mockito.anyInt())).thenReturn(teamBuildingDto2);
         teamBuildingManager.updateTeamBuildingTitleById(1, teamBuildingRequestDto.getTeamBuildingTitle());
+        teamBuildingDto2.setTeamBuildingTitle(teamBuildingRequestDto.getTeamBuildingTitle());
         TeamBuildingDto result = teamBuildingManager.readTeamBuildingById(1);
 
         //then
@@ -247,6 +247,45 @@ public class TeamBuildingServiceTest{
                 () -> Assertions.assertEquals(teamBuildingDto2.getTeamList().size(), result.getTeamList().size()),
                 () -> Assertions.assertEquals(teamBuildingDto2.getLastModifiedAt(), result.getLastModifiedAt())
         );
+
+    }
+
+    @Test
+    @DisplayName("팀빌딩 그룹 수정 실패 테스트 - teamBuildingTitle이 1000자 초과")
+    public void MODIFY_TEAM_BUILDING_FAIL_CAUSE_TEAM_BUILDING_TITLE_OVERFLOW_TEST(){
+        //given
+        int teamBuildingId = 1;
+        TeamBuildingDto teamBuildingDto = createTeamBuildingDto(teamBuildingId);
+        TeamBuildingRequestDto teamBuildingRequestDto = TeamBuildingRequestDto.builder()
+                .teamBuildingTitle(createOverflow())
+                .build();
+        TeamBuildingDto teamBuildingDto2 = teamBuildingDto;
+
+        //when
+        Mockito.when(teamBuildingRepository.isExistTeamBuilding(Mockito.anyInt())).thenReturn(true);
+        Mockito.when(teamBuildingRepository.readTeamBuildingById(Mockito.anyInt())).thenReturn(teamBuildingDto2);
+
+        //then
+        Assertions.assertThrows(ContentOverflowException.class, () ->  teamBuildingManager.updateTeamBuildingTitleById(1, teamBuildingRequestDto.getTeamBuildingTitle()));
+    }
+
+    @Test
+    @DisplayName("팀빌딩 그룹 수정 실패 테스트 - 없는 teamBuildingId")
+    public void MODIFY_TEAM_BUILDING_FAIL_CAUSE_UNKNOWN_TEAM_BUILDING_ID_TEST(){
+        //given
+        int teamBuildingId = 1;
+        TeamBuildingDto teamBuildingDto = createTeamBuildingDto(teamBuildingId);
+        TeamBuildingRequestDto teamBuildingRequestDto = TeamBuildingRequestDto.builder()
+                .teamBuildingTitle("modified Title")
+                .build();
+        TeamBuildingDto teamBuildingDto2 = teamBuildingDto;
+
+        //when
+        Mockito.when(teamBuildingRepository.isExistTeamBuilding(Mockito.anyInt())).thenReturn(false);
+        Mockito.when(teamBuildingRepository.readTeamBuildingById(Mockito.anyInt())).thenReturn(teamBuildingDto2);
+
+        //then
+        Assertions.assertThrows(UnknownTeamBuildingIdException.class, () -> teamBuildingManager.updateTeamBuildingTitleById(0,teamBuildingRequestDto.getTeamBuildingTitle()));
 
     }
 


### PR DESCRIPTION
- 팀빌딩 수정 서비스 실패 테스트 및 구현
- 없는 팀빌딩 id로 수정 시도
- 1000자 이상의 팀빌딩 제목으로 수정 시도