### PR TITLE
feat : 팀빌딩 그룹 내 팀이름 변경 서비스 예외 처리

### DIFF
--- a/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/team/management/DefaultTeamManager.java
+++ b/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/team/management/DefaultTeamManager.java
@@ -72,31 +72,6 @@ public class DefaultTeamManager implements TeamManager{
         teamRepository.updateTeamById(teamId, teamDto);
     }
 
-    private void throwIfUnknownTeamId(int teamId){
-        if(!isExistTeam(teamId)){
-            throw new UnknownTeamIdException(teamId);
-        }
-    }
-
-    private boolean isExistTeam(int teamId){return teamRepository.isExistTeam(teamId);}
-
-    private void throwIfTeamNameIsOverflow(String teamName){
-        int length = teamName.length();
-        if(length > 1000){
-            throw new ContentOverflowException("TEAMBUILDING-411", "Team name cannot be more than 1000 current length \"" + length + "\"");
-        }
-    }
-
-
-    private void throwIfDuplicatedTeamName(int teamBuildingId, String teamName){
-        List<TeamDto> teamDtoList = teamRepository.readAllTeamByTeamBuildingId(teamBuildingId);
-        for (TeamDto teamDto : teamDtoList){
-            if (teamDto.getTeamName().equals(teamName)){
-                throw new DuplicatedTeamNameException(teamName);
-            }
-        }
-    }
-
     private void throwIfUnknownUserIdDetected(List<String> userIdList){
         for (String userId : userIdList){
             if (!isExistUserId(userId)){
@@ -133,9 +108,36 @@ public class DefaultTeamManager implements TeamManager{
 
     @Override
     public void updateTeamNameById(int teamId, String teamName){
+        throwIfUnknownTeamId(teamId);
+        throwIfTeamNameIsOverflow(teamName);
         TeamDto teamDto = teamRepository.readTeamById(teamId);
+        throwIfDuplicatedTeamName(teamDto.getTeamBuildingId(), teamName);
         teamDto.setTeamName(teamName);
         teamRepository.updateTeamById(teamId, teamDto);
+    }
+
+    private void throwIfUnknownTeamId(int teamId){
+        if(!isExistTeam(teamId)){
+            throw new UnknownTeamIdException(teamId);
+        }
+    }
+
+    private boolean isExistTeam(int teamId){return teamRepository.isExistTeam(teamId);}
+
+    private void throwIfTeamNameIsOverflow(String teamName){
+        int length = teamName.length();
+        if(length > 1000){
+            throw new ContentOverflowException("TEAMBUILDING-411", "Team name cannot be more than 1000 current length \"" + length + "\"");
+        }
+    }
+
+    private void throwIfDuplicatedTeamName(int teamBuildingId, String teamName){
+        List<TeamDto> teamDtoList = teamRepository.readAllTeamByTeamBuildingId(teamBuildingId);
+        for (TeamDto teamDto : teamDtoList){
+            if (teamDto.getTeamName().equals(teamName)){
+                throw new DuplicatedTeamNameException(teamName);
+            }
+        }
     }
 
     @Override

--- a/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/team/management/DefaultTeamManager.java
+++ b/waldreg/service-layer/teambuilding/src/main/java/org/waldreg/team/management/DefaultTeamManager.java
@@ -116,14 +116,6 @@ public class DefaultTeamManager implements TeamManager{
         teamRepository.updateTeamById(teamId, teamDto);
     }
 
-    private void throwIfUnknownTeamId(int teamId){
-        if(!isExistTeam(teamId)){
-            throw new UnknownTeamIdException(teamId);
-        }
-    }
-
-    private boolean isExistTeam(int teamId){return teamRepository.isExistTeam(teamId);}
-
     private void throwIfTeamNameIsOverflow(String teamName){
         int length = teamName.length();
         if(length > 1000){
@@ -142,7 +134,16 @@ public class DefaultTeamManager implements TeamManager{
 
     @Override
     public void deleteTeamById(int teamId){
+        throwIfUnknownTeamId(teamId);
         teamRepository.deleteTeamById(teamId);
     }
+
+    private void throwIfUnknownTeamId(int teamId){
+        if(!isExistTeam(teamId)){
+            throw new UnknownTeamIdException(teamId);
+        }
+    }
+
+    private boolean isExistTeam(int teamId){return teamRepository.isExistTeam(teamId);}
 
 }

--- a/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/team/TeamServiceTest.java
+++ b/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/team/TeamServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -403,10 +404,29 @@ public class TeamServiceTest{
         //given
         int teamId = 1;
 
-        //when&then
+        //when
+        Mockito.when(teamRepository.isExistTeam(Mockito.anyInt())).thenReturn(true);
+
+        //then
         Assertions.assertDoesNotThrow(() -> teamManager.deleteTeamById(teamId));
 
     }
+
+    @Test
+    @DisplayName("팀빌딩 그룹 내 팀 삭제 실패 테스트 - 없는 team_id")
+    public void DELETE_TEAM_IN_TEAM_BUILDING_FAIL_CAUSE_UNKNOWN_TEAM_ID_TEST(){
+        //given
+        int teamId = 1;
+
+        //when
+        Mockito.when(teamRepository.isExistTeam(Mockito.anyInt())).thenReturn(false);
+
+        //then
+        Assertions.assertThrows(UnknownTeamIdException.class, () -> teamManager.deleteTeamById(teamId));
+
+    }
+
+
 
     private List<TeamDto> createTeamDtoList(int teamBuildingId){
         List<TeamDto> teamDtoList = new ArrayList<>();

--- a/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/team/TeamServiceTest.java
+++ b/waldreg/service-layer/teambuilding/src/test/java/org/waldreg/team/TeamServiceTest.java
@@ -318,6 +318,7 @@ public class TeamServiceTest{
         String updateName = "modifiedName";
 
         //when
+        Mockito.when(teamRepository.isExistTeam(Mockito.anyInt())).thenReturn(true);
         Mockito.when(teamRepository.readTeamById(Mockito.anyInt())).thenReturn(teamDto);
         teamManager.updateTeamNameById(teamId, updateName);
         teamDto.setTeamName(updateName);
@@ -331,6 +332,68 @@ public class TeamServiceTest{
                 () -> Assertions.assertEquals(teamDto.getLastModifiedAt(), result.getLastModifiedAt()),
                 () -> Assertions.assertEquals(teamDto.getUserList(), result.getUserList())
         );
+
+    }
+
+    @Test
+    @DisplayName("팀빌딩 그룹 내 팀 이름 수정 실패 테스트 - 없는 team_id")
+    public void MODIFY_TEAM_NAME_IN_TEAM_BUILDING_FAIL_CAUSE_UNKNOWN_TEAM_ID_TEST(){
+        //given
+        int teamBuildingId = 1;
+        int teamId = 0;
+        String name = "new team";
+        TeamDto teamDto = TeamDto.builder()
+                .teamBuildingId(teamBuildingId)
+                .teamId(teamId)
+                .teamName(name)
+                .userDtoList(List.of())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
+        String updateName = "modifiedName";
+
+        //when
+        Mockito.when(teamRepository.isExistTeam(Mockito.anyInt())).thenReturn(false);
+        Mockito.when(teamRepository.readTeamById(Mockito.anyInt())).thenReturn(teamDto);
+
+        //then
+        Assertions.assertThrows(UnknownTeamIdException.class, () -> teamManager.updateTeamNameById(teamId, updateName));
+
+    }
+
+    @Test
+    @DisplayName("팀빌딩 그룹 내 팀 이름 수정 실패 테스트 - 중복된 team_name")
+    public void MODIFY_TEAM_NAME_IN_TEAM_BUILDING_FAIL_CAUSE_DUPLICATED_TEAM_NAME_TEST(){
+        //given
+        int teamBuildingId = 1;
+        int teamId = 1;
+        List<TeamDto> teamDtoList = createTeamDtoList(teamBuildingId);
+        String updateName = "team 1";
+
+        //when
+        Mockito.when(teamRepository.isExistTeam(Mockito.anyInt())).thenReturn(true);
+        Mockito.when(teamRepository.readTeamById(Mockito.anyInt())).thenReturn(teamDtoList.get(0));
+        Mockito.when(teamRepository.readAllTeamByTeamBuildingId(Mockito.anyInt())).thenReturn(teamDtoList);
+
+        //then
+        Assertions.assertThrows(DuplicatedTeamNameException.class, () -> teamManager.updateTeamNameById(teamId, updateName));
+
+    }
+
+    @Test
+    @DisplayName("팀빌딩 그룹 내 팀 이름 수정 실패 테스트 - team_name 1000자 초과")
+    public void MODIFY_TEAM_NAME_IN_TEAM_BUILDING_FAIL_CAUSE_TEAM_NAME_OVERFLOW_TEST(){
+        //given
+        int teamBuildingId = 1;
+        int teamId = 1;
+        List<TeamDto> teamDtoList = createTeamDtoList(teamBuildingId);
+        String updateName = createOverflow();
+
+        //when
+        Mockito.when(teamRepository.isExistTeam(Mockito.anyInt())).thenReturn(true);
+        Mockito.when(teamRepository.readTeamById(Mockito.anyInt())).thenReturn(teamDtoList.get(0));
+
+        //then
+        Assertions.assertThrows(ContentOverflowException.class, () -> teamManager.updateTeamNameById(teamId, updateName));
 
     }
 


### PR DESCRIPTION
- 팀빌딩 그룹 내 팀이름 변경 서비스 실패 테스트 및 구현
- 없는 team_id
- 중복된 team_name
- team_name 1000자 초과