### PR TITLE
fix : character_name의 길이가 25를 넘어가지 않도록 수정

### DIFF
--- a/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/CharacterController.java
+++ b/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/CharacterController.java
@@ -79,7 +79,7 @@ public class CharacterController{
     @Authenticating
     @PermissionVerifying("Character manager")
     @PatchMapping("/character/{character-name}")
-    public void updateCharacter(@PathVariable("character-name") String characterName, @RequestBody CharacterRequest characterRequest){
+    public void updateCharacter(@PathVariable("character-name") String characterName, @RequestBody @Validated CharacterRequest characterRequest){
         characterManager.updateCharacter(characterName, controllerCharacterMapper.characterRequestToCharacterDto(characterRequest));
     }
 

--- a/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/request/CharacterRequest.java
+++ b/waldreg/application-layer/character-controller/src/main/java/org/waldreg/controller/character/request/CharacterRequest.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 public final class CharacterRequest{
 
     @NotBlank(message = "CHARACTER-413 character_name cannot be blank")
     @JsonProperty("character_name")
+    @Size(max = 25, message = "CHARACTER-418 character_name’s maximum size is 25")
     private String characterName;
 
     @NotNull(message = "CHARACTER-414 permissions cannot be null")


### PR DESCRIPTION
- character_name 필드가 25자를 넘어가면 예외 메시지를 전달하도록 수정했습니다.